### PR TITLE
Dev compatability changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+/packages

--- a/Music Manager.csproj
+++ b/Music Manager.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\PulsarLostColony.GameLibs.1.2.7.2\build\PulsarLostColony.GameLibs.props" Condition="Exists('..\packages\PulsarLostColony.GameLibs.1.2.7.2\build\PulsarLostColony.GameLibs.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -36,584 +36,584 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.2.2\lib\net472\0Harmony.dll</HintPath>
+      <HintPath>packages\Lib.Harmony.2.2.2\lib\net472\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Accessibility, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Accessibility.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Accessibility.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="ACTk.Examples.Genuine.Runtime, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\ACTk.Examples.Genuine.Runtime.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\ACTk.Examples.Genuine.Runtime.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="ACTk.Examples.Runtime, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\ACTk.Examples.Runtime.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\ACTk.Examples.Runtime.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="ACTk.Runtime, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\ACTk.Runtime.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\ACTk.Runtime.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Assembly-CSharp.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="AstarPathfindingProject, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\AstarPathfindingProject.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\AstarPathfindingProject.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Behave.Unity.Assets, Version=0.0.0.0, Culture=neutral, PublicKeyToken=e615ca22040f207c, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Behave.Unity.Assets.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Behave.Unity.Assets.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Behave.Unity.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=e615ca22040f207c, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Behave.Unity.Runtime.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Behave.Unity.Runtime.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Cinemachine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Cinemachine.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Cinemachine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="com.rlabrecque.steamworks.net, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\com.rlabrecque.steamworks.net.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\com.rlabrecque.steamworks.net.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="CrewAILibraryBuild, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\CrewAILibraryBuild.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\CrewAILibraryBuild.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="DecalSystem.Runtime, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\DecalSystem.Runtime.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\DecalSystem.Runtime.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HOTween, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\HOTween.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\HOTween.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.Data.Sqlite, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Mono.Data.Sqlite.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Mono.Data.Sqlite.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.Posix, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Mono.Posix.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Mono.Posix.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Mono.Security.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Mono.Security.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Mono.WebBrowser, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Mono.WebBrowser.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Mono.WebBrowser.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\netstandard.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\netstandard.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Novell.Directory.Ldap, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Novell.Directory.Ldap.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Novell.Directory.Ldap.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Oculus.Platform, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Oculus.Platform.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Oculus.Platform.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Oculus.VR, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Oculus.VR.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Oculus.VR.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Pathfinding.ClipperLib, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Pathfinding.ClipperLib.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Pathfinding.ClipperLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Pathfinding.Ionic.Zip.Reduced, Version=1.9.1.9000, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Pathfinding.Ionic.Zip.Reduced.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Pathfinding.Ionic.Zip.Reduced.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Pathfinding.Poly2Tri, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Pathfinding.Poly2Tri.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Pathfinding.Poly2Tri.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Photon3Unity3D, Version=4.1.6.10, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Photon3Unity3D.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Photon3Unity3D.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="PilotAIBuild, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\PilotAIBuild.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\PilotAIBuild.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="PLInputBase, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\PLInputBase.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\PLInputBase.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\protobuf-net.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\protobuf-net.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="PulsarModLoader">
-      <HintPath>..\packages\PulsarModLoader.dll</HintPath>
+      <HintPath>packages\PulsarModLoader.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="RestSharp, Version=104.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\RestSharp.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\RestSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SteamVR, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\SteamVR.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\SteamVR.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="SteamVR_Actions, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\SteamVR_Actions.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\SteamVR_Actions.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.ComponentModel.Composition.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.ComponentModel.Composition.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.ComponentModel.DataAnnotations.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.ComponentModel.DataAnnotations.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Configuration.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Configuration.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Data.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Data.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Design.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Design.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Diagnostics.StackTrace, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Diagnostics.StackTrace.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Diagnostics.StackTrace.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.DirectoryServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.DirectoryServices.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.DirectoryServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Drawing.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Drawing.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Drawing.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Drawing.Design.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Drawing.Design.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.EnterpriseServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.EnterpriseServices.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.EnterpriseServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Globalization.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Globalization.Extensions.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Globalization.Extensions.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.IO.Compression, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.IO.Compression.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.IO.Compression.dll</HintPath>
       <Private>True</Private>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.IO.Compression.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.IO.Compression.FileSystem.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.IO.Compression.FileSystem.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Net.Http.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Net.Http.dll</HintPath>
       <Private>True</Private>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Numerics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Numerics.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Numerics.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Runtime.Serialization.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Runtime.Serialization.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization.Formatters.Soap, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Runtime.Serialization.Formatters.Soap.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Runtime.Serialization.Formatters.Soap.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization.Xml, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Runtime.Serialization.Xml.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Runtime.Serialization.Xml.dll</HintPath>
       <Private>True</Private>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Security.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Security.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.ServiceModel.Internals, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.ServiceModel.Internals.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.ServiceModel.Internals.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Transactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Transactions.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Transactions.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Web.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Web.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.ApplicationServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Web.ApplicationServices.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Web.ApplicationServices.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.Services, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Web.Services.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Web.Services.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Windows.Forms.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Windows.Forms.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Xml.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Xml.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Xml.Linq.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Xml.Linq.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Xml.XPath.XDocument, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Xml.XPath.XDocument.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\System.Xml.XPath.XDocument.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.Analytics.DataPrivacy, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.Analytics.DataPrivacy.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.Analytics.DataPrivacy.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.InputSystem, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.InputSystem.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.InputSystem.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.Recorder, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.Recorder.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.Recorder.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.Recorder.Base, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.Recorder.Base.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.Recorder.Base.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.Subsystem.Registration, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.Subsystem.Registration.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.Subsystem.Registration.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.TerrainTools, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.TerrainTools.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.TerrainTools.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.TextMeshPro, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.TextMeshPro.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.TextMeshPro.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.Timeline, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.Timeline.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.Timeline.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.XR.Management, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.XR.Management.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.XR.Management.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Unity.XR.OpenVR, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.XR.OpenVR.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Unity.XR.OpenVR.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AccessibilityModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AccessibilityModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AccessibilityModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AIModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AndroidJNIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AndroidJNIModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AndroidJNIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AnimationModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ARModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ARModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ARModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.AudioModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ClothModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ClothModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ClothModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ClusterInputModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ClusterInputModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ClusterInputModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ClusterRendererModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ClusterRendererModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ClusterRendererModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CrashReportingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.CrashReportingModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.CrashReportingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.DirectorModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.DirectorModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.DirectorModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.DSPGraphModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.DSPGraphModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.DSPGraphModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.GameCenterModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.GameCenterModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.GameCenterModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.GIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.GIModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.GIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.GridModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.GridModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.GridModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.HotReloadModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.HotReloadModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.HotReloadModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.InputLegacyModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.InputModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.InputModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.InputModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.JSONSerializeModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.JSONSerializeModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.JSONSerializeModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.LocalizationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.LocalizationModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.LocalizationModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ParticleSystemModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PerformanceReportingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.PerformanceReportingModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.PerformanceReportingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.Physics2DModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.Physics2DModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.Physics2DModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ProfilerModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ProfilerModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ProfilerModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ScreenCaptureModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ScreenCaptureModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.ScreenCaptureModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SharedInternalsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SharedInternalsModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SharedInternalsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SpatialTracking, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SpatialTracking.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SpatialTracking.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SpriteMaskModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SpriteMaskModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SpriteMaskModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SpriteShapeModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SpriteShapeModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SpriteShapeModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.StreamingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.StreamingModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.StreamingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SubstanceModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SubstanceModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SubstanceModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.SubsystemsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SubsystemsModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.SubsystemsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TerrainModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TerrainModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TerrainModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TerrainPhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TerrainPhysicsModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TerrainPhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextCoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TextCoreModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TextCoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TextRenderingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TilemapModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TilemapModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TilemapModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.TLSModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TLSModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.TLSModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UI.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIElementsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UIElementsModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UIElementsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIElementsNativeModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UIElementsNativeModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UIElementsNativeModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UmbraModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UmbraModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UmbraModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UNETModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UNETModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UNETModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityAnalyticsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityAnalyticsModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityAnalyticsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityConnectModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityConnectModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityConnectModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityCurlModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityCurlModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityCurlModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityTestProtocolModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityTestProtocolModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityTestProtocolModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityWebRequestModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestTextureModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VehiclesModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.VehiclesModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.VehiclesModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VFXModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.VFXModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.VFXModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VideoModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.VideoModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.VideoModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VirtualTexturingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.VirtualTexturingModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.VirtualTexturingModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.VRModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.VRModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.VRModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.WindModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.WindModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.WindModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.XR.LegacyInputHelpers, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.XR.LegacyInputHelpers.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.XR.LegacyInputHelpers.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.XRModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.XRModule.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\UnityEngine.XRModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Valve.Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Valve.Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\Valve.Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="websocket-sharp, Version=1.0.2.59611, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
-      <HintPath>..\packages\PulsarLostColony.GameLibs.1.2.7.2\lib\websocket-sharp.dll</HintPath>
+      <HintPath>packages\PulsarLostColony.GameLibs.1.2.7.2\lib\websocket-sharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -725,7 +725,12 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\PulsarLostColony.GameLibs.1.2.7.2\build\PulsarLostColony.GameLibs.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PulsarLostColony.GameLibs.1.2.7.2\build\PulsarLostColony.GameLibs.props'))" />
+    <Error Condition="!Exists('packages\PulsarLostColony.GameLibs.1.2.7.2\build\PulsarLostColony.GameLibs.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\PulsarLostColony.GameLibs.1.2.7.2\build\PulsarLostColony.GameLibs.props'))" />
+  </Target>
+  <!-- Warning message if someone used Nuget to build packages directory but havent imported PulsarModLoader.dll-->
+  <Target Name="CheckPulsarModLoaderReference" BeforeTargets="PrepareForBuild">
+    <Message Importance="high" Condition="!Exists('packages\PulsarModLoader.dll')" Text="⚠️ PulsarModLoader.dll not found in 'packages' folder. Please place it at packages/PulsarModLoader.dll before building." />
+    <Warning Condition="!Exists('packages\PulsarModLoader.dll')" Text="PulsarModLoader.dll is missing from packages/. Please add it before building." />
   </Target>
   <!-- Copy extra files from solution dir to output dir (e.g., README.md) -->
   <Target Name="CopyMarkdownFiles" AfterTargets="AfterBuild">

--- a/Music Manager.csproj
+++ b/Music Manager.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\PulsarLostColony.GameLibs.1.2.7.2\build\PulsarLostColony.GameLibs.props" Condition="Exists('..\packages\PulsarLostColony.GameLibs.1.2.7.2\build\PulsarLostColony.GameLibs.props')" />
+  <Import Project="packages\PulsarLostColony.GameLibs.1.2.7.2\build\PulsarLostColony.GameLibs.props" Condition="Exists('packages\PulsarLostColony.GameLibs.1.2.7.2\build\PulsarLostColony.GameLibs.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/packages
+++ b/packages
@@ -1,1 +1,0 @@
-../packages


### PR DESCRIPTION
Couple of changes so that developers can just click the "Open With Visual Studio" button from github and the references and packages work out of the box.
Will need to manually import `PulsarModLoader.dll` into the `packages/` folder so I also added a little message about it.